### PR TITLE
Add .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+# byte compiled
+__pycache__/
+*.py[cod]
+
+# distribution / packaging
+dist/
+
+# environments
+.env
+.venv
+env/
+venv/
+env.bak/
+venv.bak/
+
+# pycharm configuration
+.idea


### PR DESCRIPTION
Some base ignores that will make our lives a lot easier.

AFAICT, this is the only file that doesn't need a license at the top, because our big sibling over here[1] don't.

[1] https://github.com/googleapis/google-api-python-client/blob/master/.gitignore